### PR TITLE
Add CLI for filtering text files with Philter

### DIFF
--- a/philterx/cli.py
+++ b/philterx/cli.py
@@ -1,0 +1,37 @@
+import argparse
+from pathlib import Path
+import shutil
+import tempfile
+import yaml
+from philter import Philter
+
+
+def main() -> None:
+    """Command line interface for running Philter on text files."""
+    parser = argparse.ArgumentParser(description="Filter PHI from text files")
+    parser.add_argument("--input", required=True, help="Directory containing .txt files to filter")
+    parser.add_argument("--output", required=True, help="Directory to write filtered files")
+    parser.add_argument("--config", required=True, help="YAML configuration for Philter")
+    args = parser.parse_args()
+
+    input_dir = Path(args.input)
+    output_dir = Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    config_path = Path(args.config)
+    config = yaml.safe_load(config_path.read_text())
+
+    for txt_file in input_dir.rglob("*.txt"):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            shutil.copy(txt_file, tmp_path / txt_file.name)
+            cfg = dict(config)
+            cfg["finpath"] = str(tmp_path)
+            cfg["foutpath"] = str(output_dir)
+            filterer = Philter(cfg)
+            filterer.map_coordinates()
+            filterer.transform()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,11 @@ dependencies = [
   "numpy>=1.22.0",
   "pandas>=1.0.5",
   "xmltodict>=0.12.0",
+  "pyyaml>=6.0",
 ]
 
 [project.scripts]
-philterx = "philter_ucsf.__main__:main"
+philterx = "philterx.cli:main"
 
 [tool.setuptools]
 include-package-data = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ nltk>=3.6.6
 numpy>=1.22.0
 pandas>=1.0.5
 xmltodict>=0.12.0
+PyYAML>=6.0


### PR DESCRIPTION
## Summary
- add `philterx.cli` to filter `.txt` files using Philter and YAML config
- register `philterx` console script in packaging and include PyYAML dependency
- document PyYAML requirement

## Testing
- `python -m py_compile philterx/cli.py`
- `python -m pytest`
- `python -m philterx.cli --help`


------
https://chatgpt.com/codex/tasks/task_e_68b9eece0de083279bac9cf64ad5f615