### PR TITLE
Add YAML config loader and CLI integration

### DIFF
--- a/configs/default.yml
+++ b/configs/default.yml
@@ -1,0 +1,8 @@
+dates: remove
+replacement:
+  style: asterisk
+whitelist: []
+blacklist: []
+eval:
+  enabled: false
+  gold_dir: ""

--- a/philterx/__init__.py
+++ b/philterx/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for running the Philter CLI"""
+
+from .config import Config, load_config
+
+__all__ = ["Config", "load_config"]

--- a/philterx/cli.py
+++ b/philterx/cli.py
@@ -1,9 +1,62 @@
 import argparse
 from pathlib import Path
-import shutil
+import re
 import tempfile
-import yaml
+from datetime import datetime, timedelta
+
 from philter import Philter
+from philterx.config import load_config
+
+DATE_RE = re.compile(r"\b(\d{4}-\d{2}-\d{2})\b")
+
+
+def _restore_placeholders(text: str, mapping: dict[str, str]) -> str:
+    for placeholder, value in mapping.items():
+        text = text.replace(placeholder, value)
+    return text
+
+
+def _apply_whitelist(text: str, terms: list[str]):
+    mapping = {}
+    for i, term in enumerate(terms):
+        placeholder = f"PHILTERXWL{i}"
+        mapping[placeholder] = term
+        text = text.replace(term, placeholder)
+    return text, mapping
+
+
+def _apply_blacklist(text: str, terms: list[str], style: str) -> str:
+    def repl(term: str) -> str:
+        if style == "redacted":
+            return "[REDACTED]"
+        if style == "pseudonym":
+            return "[PSEUDONYM]"
+        return "*" * len(term)
+
+    for term in terms:
+        text = re.sub(re.escape(term), repl(term), text)
+    return text
+
+
+def _handle_dates(text: str, mode: str):
+    mapping = {}
+    if mode in {"keep", "shift"}:
+        matches = list(DATE_RE.finditer(text))
+        for i, m in enumerate(matches):
+            original = m.group(1)
+            placeholder = f"PHILTERXDATE{i}"
+            if mode == "shift":
+                try:
+                    dt = datetime.strptime(original, "%Y-%m-%d").date()
+                    dt = dt + timedelta(days=1)
+                    replacement = dt.strftime("%Y-%m-%d")
+                except ValueError:
+                    replacement = original
+            else:
+                replacement = original
+            mapping[placeholder] = replacement
+            text = text.replace(original, placeholder, 1)
+    return text, mapping
 
 
 def main() -> None:
@@ -18,19 +71,30 @@ def main() -> None:
     output_dir = Path(args.output)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    config_path = Path(args.config)
-    config = yaml.safe_load(config_path.read_text())
+    cfg = load_config(args.config)
+    base_opts = cfg.to_philter_options()
 
     for txt_file in input_dir.rglob("*.txt"):
+        original = txt_file.read_text()
+        pre_text, wl_map = _apply_whitelist(original, cfg.whitelist)
+        pre_text, date_map = _handle_dates(pre_text, cfg.dates)
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp_path = Path(tmpdir)
-            shutil.copy(txt_file, tmp_path / txt_file.name)
-            cfg = dict(config)
-            cfg["finpath"] = str(tmp_path)
-            cfg["foutpath"] = str(output_dir)
-            filterer = Philter(cfg)
+            temp_file = tmp_path / txt_file.name
+            temp_file.write_text(pre_text)
+            philter_opts = dict(base_opts)
+            philter_opts["finpath"] = str(tmp_path)
+            philter_opts["foutpath"] = str(output_dir)
+            filterer = Philter(philter_opts)
             filterer.map_coordinates()
             filterer.transform()
+
+            out_file = output_dir / txt_file.name
+            filtered = out_file.read_text()
+            filtered = _restore_placeholders(filtered, wl_map)
+            filtered = _restore_placeholders(filtered, date_map)
+            filtered = _apply_blacklist(filtered, cfg.blacklist, cfg.replacement.style)
+            out_file.write_text(filtered)
 
 
 if __name__ == "__main__":

--- a/philterx/config.py
+++ b/philterx/config.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Literal
+
+import yaml
+
+
+@dataclass
+class Replacement:
+    style: Literal["asterisk", "redacted", "pseudonym"] = "asterisk"
+
+
+@dataclass
+class Eval:
+    enabled: bool = False
+    gold_dir: str = ""
+
+
+@dataclass
+class Config:
+    dates: Literal["keep", "remove", "shift"] = "remove"
+    replacement: Replacement = field(default_factory=Replacement)
+    whitelist: List[str] = field(default_factory=list)
+    blacklist: List[str] = field(default_factory=list)
+    eval: Eval = field(default_factory=Eval)
+
+    def to_philter_options(self) -> dict:
+        opts = {}
+        opts["outformat"] = self.replacement.style
+        if self.eval.enabled:
+            opts["run_eval"] = True
+            opts["anno_folder"] = self.eval.gold_dir
+        return opts
+
+
+def load_config(path: str | Path) -> Config:
+    data = yaml.safe_load(Path(path).read_text())
+    replacement = data.get("replacement", {})
+    eval_cfg = data.get("eval", {})
+    return Config(
+        dates=data.get("dates", "remove"),
+        replacement=Replacement(style=replacement.get("style", "asterisk")),
+        whitelist=list(data.get("whitelist", []) or []),
+        blacklist=list(data.get("blacklist", []) or []),
+        eval=Eval(
+            enabled=eval_cfg.get("enabled", False),
+            gold_dir=eval_cfg.get("gold_dir", ""),
+        ),
+    )


### PR DESCRIPTION
## Summary
- introduce typed configuration loader using yaml.safe_load
- enhance CLI to merge configuration with runtime options and inject whitelist/blacklist terms
- provide example default configuration file

## Testing
- `python -m py_compile philterx/config.py philterx/cli.py philterx/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9f01a095c83279e0d74fccb0420c8