### PR TITLE
Expose more Philter runtime options

### DIFF
--- a/philterx/cli.py
+++ b/philterx/cli.py
@@ -4,8 +4,6 @@ import re
 import tempfile
 from datetime import datetime, timedelta
 import json
-import yaml
-import importlib.resources as pkg_resources
 
 from philter import Philter
 from philterx.config import load_config
@@ -77,30 +75,6 @@ def main() -> None:
     cfg = load_config(args.config)
     base_opts = cfg.to_philter_options()
 
-    raw_cfg: dict = {}
-    default_cfg = Path(__file__).with_name("config.yaml")
-    if default_cfg.exists():
-        raw_cfg.update(yaml.safe_load(default_cfg.read_text()) or {})
-    raw_cfg.update(yaml.safe_load(Path(args.config).read_text()) or {})
-
-    extra_opts = {}
-    default_filters = pkg_resources.files("philter_ucsf") / "configs" / "philter_delta.json"
-    extra_opts["filters"] = raw_cfg.get("filters", str(default_filters))
-
-    for key in (
-        "xml",
-        "stanford_ner_tagger",
-        "freq_table",
-        "initials",
-        "coords",
-        "eval_out",
-        "ucsfformat",
-        "cachepos",
-        "verbose",
-    ):
-        if key in raw_cfg:
-            extra_opts[key] = raw_cfg[key]
-
     for txt_file in input_dir.rglob("*.txt"):
         original = txt_file.read_text()
         pre_text, wl_map = _apply_whitelist(original, cfg.whitelist)
@@ -110,7 +84,6 @@ def main() -> None:
             temp_file = tmp_path / txt_file.name
             temp_file.write_text(pre_text)
             philter_opts = dict(base_opts)
-            philter_opts.update(extra_opts)
             philter_opts["finpath"] = str(tmp_path)
             philter_opts["foutpath"] = str(output_dir)
             filterer = Philter(philter_opts)

--- a/philterx/config.py
+++ b/philterx/config.py
@@ -2,9 +2,30 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Literal
+from typing import Dict, List, Literal
 
+import importlib.resources as pkg_resources
 import yaml
+
+
+def _pkg_path(*parts: str) -> str:
+    return str(pkg_resources.files("philter_ucsf").joinpath(*parts))
+
+
+def _default_filters() -> str:
+    return _pkg_path("configs", "philter_delta.json")
+
+
+def _default_xml() -> str:
+    return _pkg_path("data", "phi_notes_i2b2.json")
+
+
+def _default_coords() -> str:
+    return _pkg_path("data", "coordinates.json")
+
+
+def _default_eval_out() -> str:
+    return _pkg_path("data", "phi")
 
 
 @dataclass
@@ -25,13 +46,37 @@ class Config:
     whitelist: List[str] = field(default_factory=list)
     blacklist: List[str] = field(default_factory=list)
     eval: Eval = field(default_factory=Eval)
+    filters: str = field(default_factory=_default_filters)
+    xml: str = field(default_factory=_default_xml)
+    stanford_ner_tagger: Dict[str, str | bool] = field(default_factory=dict)
+    freq_table: bool = False
+    initials: bool = True
+    coords: str = field(default_factory=_default_coords)
+    eval_out: str = field(default_factory=_default_eval_out)
+    ucsfformat: bool = False
+    cachepos: str = ""
+    verbose: bool = True
 
     def to_philter_options(self) -> dict:
-        opts = {}
-        opts["outformat"] = self.replacement.style
+        opts = {"outformat": self.replacement.style}
         if self.eval.enabled:
             opts["run_eval"] = True
             opts["anno_folder"] = self.eval.gold_dir
+        for key in (
+            "filters",
+            "xml",
+            "stanford_ner_tagger",
+            "freq_table",
+            "initials",
+            "coords",
+            "eval_out",
+            "ucsfformat",
+            "cachepos",
+            "verbose",
+        ):
+            value = getattr(self, key)
+            if value:
+                opts[key] = value
         return opts
 
 
@@ -48,4 +93,14 @@ def load_config(path: str | Path) -> Config:
             enabled=eval_cfg.get("enabled", False),
             gold_dir=eval_cfg.get("gold_dir", ""),
         ),
+        filters=data.get("filters", _default_filters()),
+        xml=data.get("xml", _default_xml()),
+        stanford_ner_tagger=dict(data.get("stanford_ner_tagger", {}) or {}),
+        freq_table=data.get("freq_table", False),
+        initials=data.get("initials", True),
+        coords=data.get("coords", _default_coords()),
+        eval_out=data.get("eval_out", _default_eval_out()),
+        ucsfformat=data.get("ucsfformat", False),
+        cachepos=data.get("cachepos", ""),
+        verbose=data.get("verbose", True),
     )


### PR DESCRIPTION
## Summary
- add optional config fields for filters, xml, Stanford NER tagger, caching and more with default paths
- emit all non-empty config fields as Philter options
- streamline CLI to forward config options directly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba015b54bc83279a4af60667f31bd3