### PR TITLE
docs: update quick start for philterx

### DIFF
--- a/READTHIS.md
+++ b/READTHIS.md
@@ -1,57 +1,62 @@
 # Quick Start Guide
 
-This guide summarizes the basics of running **Philter** from the command line.
+This guide summarizes the basics of running **philterx** from the command line.
 
 ## Installation
-- Install the package from PyPI:
-  ```bash
-  pip3 install philter-ucsf
-  ```
-- Or work from source by cloning this repository and installing the dependencies:
-  ```bash
-  git clone https://github.com/.../philter-ucsf-ChatGPT.git
-  pip3 install -r requirements.txt
-  ```
-
-## Command-line usage
-Run Philter against a directory of notes:
+Install from PyPI:
 ```bash
-python3 main.py -i ./data/i2b2_notes/ -o ./data/i2b2_results/ -f ./configs/philter_delta.json
+pip3 install philter-ucsf
 ```
-Key flags:
-- `-i` – input note directory or file.
-- `-o` – output directory for PHI-reduced notes.
-- `-f` – path to the configuration JSON controlling PHI rules.
-- `-a` – optional annotation directory when evaluating.
+or work from source by cloning this repository and installing the dependencies:
+```bash
+git clone https://github.com/.../philter-ucsf-ChatGPT.git
+pip3 install -r requirements.txt
+```
+
+## Quick start
+This repository provides a sample configuration at `config.yaml`.  
+Filter a directory of text files by running:
+```bash
+philterx --input ./data/i2b2_notes/ --output ./data/i2b2_results/ --config config.yaml
+```
+
+## Configuration
+`philterx` reads options from a YAML file. Key fields include:
+
+- `dates`: how to treat detected dates – `keep`, `remove` or `shift`.
+- `replacement.style`: format used for PHI spans (`asterisk`, `redacted`, or `pseudonym`).
+- `filters`: JSON file listing active filters.
+- `whitelist` / `blacklist`: lists of JSON files containing terms to always keep or always remove.
+- `eval.enabled` and `eval.gold_dir`: enable evaluation and point to gold-standard annotations.
+- `xml`, `stanford_ner_tagger`, `freq_table`, `initials`, `coords`, `eval_out`, `ucsfformat`, `cachepos`, `verbose`: advanced options passed directly to the underlying `Philter` engine.
+
+## Default resources
+If a path is not provided in `config.yaml`, built‑in resources are used:
+
+- `config/default_filters.json` – default PHI filter definitions.
+- `resources/whitelists/whitelist_plus_fps_091718_nonames.json` – default whitelist terms.
+- `resources/blacklists/firstnames_minus_fps.json` – default blacklist terms.
+- `philter_ucsf/data/phi_notes_i2b2.json` – sample XML notes for evaluation.
+- `philter_ucsf/data/coordinates.json` – coordinate mappings for annotations.
+- `philter_ucsf/data/phi` – default directory for evaluation outputs.
 
 ## Editing whitelist and blacklist
-Philter ships with JSON files listing terms to always keep or remove:
-- Whitelists live under `filters/whitelists/`
-- Blacklists live under `filters/blacklists/`
-Add or delete entries from these JSON files to customize behavior. The configuration file references these lists when running.
-
-## PHI options
-The file `configs/philter_delta.json` defines which PHI filters are active and how they behave. Tweak this file to enable or disable specific PHI categories or to point at different whitelist/blacklist files. Additional flags such as `-n` (include initials) and `-t` (emit word-frequency table) further control PHI reporting.
+Add or remove entries from the JSON files listed under `whitelist` and `blacklist` in the configuration to customize term handling.
 
 ## Replacement styles
-Control how detected PHI appears in the output via `--outputformat`:
-- `asterisk` – replaces PHI spans with `*` characters.
-- `i2b2` – writes the original text with XML tags around PHI spans.
+The `replacement.style` field determines how detected PHI appears in output:
+- `asterisk` – replace spans with `*`.
+- `redacted` – insert `[REDACTED]`.
+- `pseudonym` – insert `[PSEUDONYM]`.
 
-## Evaluation toggle
-To score Philter against ground-truth annotations, supply the annotation directory and enable evaluation:
-```bash
-python3 main.py -i NOTES -a ANNO -o OUTPUT -x ./data/phi_notes.json -f ./configs/philter_delta.json -e
-```
-Omit `-e` (or pass `--prod=True`) to skip evaluation and simply generate PHI-reduced text.
+## Evaluation
+Set `eval.enabled: true` and provide `eval.gold_dir` to produce precision/recall metrics.  
+Without evaluation, `philterx` simply writes PHI‑reduced text.
 
 ## Regex pattern formats
-Regular-expression filters may be written in one of two forms:
+Regular-expression filters may be written in two forms:
 
 - Raw patterns using Python syntax, e.g. `(?i)foo`.
-- Delimited form `/pattern/flags`, where trailing flags map to Python's `re`
-  options (`i`, `m`, `s`, `x`).
+- Delimited form `/pattern/flags`, where trailing flags map to Python's `re` options (`i`, `m`, `s`, `x`).
 
-Inline flag blocks such as `(?im)` can appear anywhere in the pattern; they are
-stripped and moved to the beginning before compilation. Any regex that fails to
-compile is skipped with a warning instead of stopping the program.
+Inline flag blocks such as `(?im)` can appear anywhere in the pattern; they are stripped and moved to the beginning before compilation. Any regex that fails to compile is skipped with a warning instead of stopping the program.


### PR DESCRIPTION
## Summary
- revise quick-start guide for the new `philterx` CLI
- document config.yaml fields and default resource locations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba052f7b5083279098a931f0e32e0d