### PR TITLE
Refactor CLI to use Config option builder

### DIFF
--- a/philterx/cli.py
+++ b/philterx/cli.py
@@ -82,25 +82,9 @@ def main() -> None:
             tmp_path = Path(tmpdir)
             temp_file = tmp_path / txt_file.name
             temp_file.write_text(pre_text)
-            philter_opts = {
-                "finpath": str(tmp_path),
-                "foutpath": str(output_dir),
-                "filters": cfg.filters,
-                "xml": cfg.xml,
-                "freq_table": cfg.freq_table,
-                "initials": cfg.initials,
-                "coords": cfg.coords,
-                "eval_out": cfg.eval_out,
-                "ucsfformat": cfg.ucsfformat,
-                "cachepos": cfg.cachepos,
-                "verbose": cfg.verbose,
-                "outformat": cfg.replacement.style,
-            }
-            if cfg.stanford_ner_tagger:
-                philter_opts["stanford_ner_tagger"] = cfg.stanford_ner_tagger
-            if cfg.eval.enabled:
-                philter_opts["run_eval"] = True
-                philter_opts["anno_folder"] = cfg.eval.gold_dir
+            philter_opts = cfg.to_philter_options()
+            philter_opts["finpath"] = str(tmp_path)
+            philter_opts["foutpath"] = str(output_dir)
             filterer = Philter(philter_opts)
             filterer.map_coordinates()
             filterer.transform()


### PR DESCRIPTION
## Summary
- use `Config.to_philter_options()` in CLI instead of manually building options

## Testing
- `pytest -q`
- `python -m philterx.cli --input /tmp/input_cli_empty --output /tmp/output_cli_empty --config /tmp/tmp_cli_config.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68ba22fec2048327a6281577951a4f57