### PR TITLE
Use os.path.join for file paths

### DIFF
--- a/philter_ucsf/philter.py
+++ b/philter_ucsf/philter.py
@@ -819,16 +819,16 @@ class Philter:
             #keeps a record of all phi coordinates and text for a given file
             # data = {}
         
-            filename = root+f
+            filename = os.path.join(root, f)
 
             encoding = self.detect_encoding(filename)
-            txt = open(filename,"r", encoding=encoding['encoding']).read()
+            txt = open(filename, "r", encoding=encoding['encoding']).read()
 
 
 
             #now we transform the text
             fbase, fext = os.path.splitext(f)
-            outpathfbase = out_path + fbase
+            outpathfbase = os.path.join(out_path, fbase)
             if self.outformat == "asterisk":
                 with open(outpathfbase+".txt", "w", encoding='utf-8', errors='surrogateescape') as f:
                     contents = self.transform_text_asterisk(txt, filename)


### PR DESCRIPTION
## Summary
- Build filenames and output paths with `os.path.join` in `philter.py` for safer path handling

## Testing
- `python -m philterx.cli --input data/i2b2_notes --output /tmp/philterx_out --config /tmp/config_with_eval.yaml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba24e255e08327bf63d0e4f26ca92a