### PR TITLE
Add default filters fallback in Philter

### DIFF
--- a/philter_ucsf/philter.py
+++ b/philter_ucsf/philter.py
@@ -78,6 +78,20 @@ class Philter:
             if not os.path.exists(config["filters"]):
                 raise Exception("Filepath does not exist", config["filters"])
             self.patterns = json.loads(open(config["filters"], "r").read())
+        else:
+            default_filters_path = os.path.join(
+                os.path.dirname(os.path.dirname(__file__)),
+                "config",
+                "default_filters.json",
+            )
+            if os.path.exists(default_filters_path):
+                self.patterns = json.loads(open(default_filters_path, "r").read())
+            else:
+                raise KeyError(
+                    "'filters' not specified in config and default filters not found at {}".format(
+                        default_filters_path
+                    )
+                )
 
         if "xml" in config:
             if not os.path.exists(config["xml"]):


### PR DESCRIPTION
## Summary
- raise error when custom filters path missing and fallback to bundled `config/default_filters.json`
- compile philter module

## Testing
- `python -m py_compile philter_ucsf/philter.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba28941a9c83279b9d01e5f1356dad