### PR TITLE
Ensure CLI forwards full Philter options

### DIFF
--- a/philterx/cli.py
+++ b/philterx/cli.py
@@ -83,6 +83,19 @@ def main() -> None:
             temp_file = tmp_path / txt_file.name
             temp_file.write_text(pre_text)
             philter_opts = cfg.to_philter_options()
+            for key in [
+                "filters",
+                "xml",
+                "stanford_ner_tagger",
+                "freq_table",
+                "initials",
+                "coords",
+                "eval_out",
+                "ucsfformat",
+                "cachepos",
+                "verbose",
+            ]:
+                philter_opts.setdefault(key, getattr(cfg, key, None))
             philter_opts["finpath"] = str(tmp_path)
             philter_opts["foutpath"] = str(output_dir)
             filterer = Philter(philter_opts)

--- a/philterx/config.py
+++ b/philterx/config.py
@@ -72,32 +72,26 @@ class Config:
     verbose: bool = True
 
     def to_philter_options(self) -> dict:
-        opts = {"outformat": self.replacement.style}
+        opts = {
+            "outformat": self.replacement.style,
+            "filters": str(self.filters),
+            "xml": str(self.xml) if self.xml else None,
+            "stanford_ner_tagger": {
+                k: str(v) for k, v in self.stanford_ner_tagger.items()
+            }
+            if self.stanford_ner_tagger
+            else None,
+            "freq_table": self.freq_table,
+            "initials": self.initials,
+            "coords": str(self.coords),
+            "eval_out": str(self.eval_out),
+            "ucsfformat": self.ucsfformat,
+            "cachepos": self.cachepos,
+            "verbose": self.verbose,
+        }
         if self.eval.enabled:
             opts["run_eval"] = True
             opts["anno_folder"] = self.eval.gold_dir
-        if self.filters:
-            opts["filters"] = str(self.filters)
-        if self.xml:
-            opts["xml"] = str(self.xml)
-        if self.stanford_ner_tagger:
-            opts["stanford_ner_tagger"] = {
-                k: str(v) for k, v in self.stanford_ner_tagger.items()
-            }
-        if self.freq_table:
-            opts["freq_table"] = self.freq_table
-        if self.initials is not None:
-            opts["initials"] = self.initials
-        if self.coords:
-            opts["coords"] = str(self.coords)
-        if self.eval_out:
-            opts["eval_out"] = str(self.eval_out)
-        if self.ucsfformat:
-            opts["ucsfformat"] = self.ucsfformat
-        if self.cachepos:
-            opts["cachepos"] = self.cachepos
-        if self.verbose:
-            opts["verbose"] = self.verbose
         return opts
 
 

--- a/tests/test_cli_philter_opts.py
+++ b/tests/test_cli_philter_opts.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from philterx import cli
+
+
+def test_cli_passes_all_options(tmp_path, monkeypatch):
+    # prepare input and output directories
+    in_dir = tmp_path / "in"
+    out_dir = tmp_path / "out"
+    in_dir.mkdir()
+    out_dir.mkdir()
+
+    (in_dir / "note.txt").write_text("dummy text")
+
+    # minimal config
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text("{}")
+
+    captured = {}
+
+    class DummyPhilter:
+        def __init__(self, opts):
+            captured.update(opts)
+
+        def map_coordinates(self):
+            pass
+
+        def transform(self):
+            out_file = Path(captured["foutpath"]) / "note.txt"
+            out_file.write_text("filtered")
+
+    monkeypatch.setattr(cli, "Philter", lambda opts: DummyPhilter(opts))
+
+    args = [
+        "philterx", "--input", str(in_dir), "--output", str(out_dir), "--config", str(cfg_path)
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+
+    cli.main()
+
+    required = [
+        "filters",
+        "xml",
+        "stanford_ner_tagger",
+        "freq_table",
+        "initials",
+        "coords",
+        "eval_out",
+        "ucsfformat",
+        "cachepos",
+        "verbose",
+        "finpath",
+        "foutpath",
+    ]
+    for key in required:
+        assert key in captured


### PR DESCRIPTION
## Summary
- Always populate Philter option defaults (filters, xml, tagger, etc.)
- Ensure CLI adds all options along with finpath/foutpath
- Add smoke test verifying CLI forwards required options to Philter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba2976693c8327a32210cb832fe21c